### PR TITLE
Skip all custom logic when `SHOULD_BUILD` is passed

### DIFF
--- a/docker/cli/entrypoint.sh
+++ b/docker/cli/entrypoint.sh
@@ -19,14 +19,14 @@ if [ "$1" = "build" ]; then
     esac
 
 
-    # By default use previous commit as REF
-    PREVIOUS_REF=$(git rev-parse HEAD^1)
 
     # IF there is a tag, use the tag
     if [ -n "$TAG" ]; then
         # tries to get the previous tag. If first one, return same
         PREVIOUS_REF="$(git describe --tags --abbrev=0 "tags/$TAG^" || echo $TAG)"
-
+    else
+        # By default use previous commit as REF
+        PREVIOUS_REF=$(git rev-parse HEAD^1)
     fi
 
 


### PR DESCRIPTION
`HEAD^1` sometimes fails with:
```
fatal: ambiguous argument 'HEAD^1': unknown revision or path not in the working tree.
```
([see it for real here](https://github.com/vercel/api/runs/3051051847?check_suite_focus=true#step:8:11))

In this case, we pass `SHOULD_BUILD=1` so we don't need to run any of the "should build" logic and we can just skip it and continue with the `docker build`command.