### PR TITLE
Always run in `SHOULD_BUILD=1` mode

### DIFF
--- a/docker/cli/entrypoint.sh
+++ b/docker/cli/entrypoint.sh
@@ -1,59 +1,5 @@
 #!/bin/sh -l
-set -x
-env | sort
 
 set -eo pipefail
-
-if [ "$1" = "build" ]; then
-
-    test -z "$PROJECT_PATH" && {
-            echo "no PROJECT_PATH provided" >&2
-            exit 1
-    }
-
-    # Check if it's a tag
-    case "$GITHUB_REF" in 
-        refs/tags/*)
-            TAG=$(echo "$GITHUB_REF" | cut -f3 -d'/')
-            ;;
-    esac
-
-
-    # By default use previous commit as REF
-    PREVIOUS_REF=$(git rev-parse HEAD^1)
-
-    # IF there is a tag, use the tag
-    if [ -n "$TAG" ]; then
-        # tries to get the previous tag. If first one, return same
-        PREVIOUS_REF="$(git describe --tags --abbrev=0 "tags/$TAG^" || echo $TAG)"
-
-    fi
-
-
-    should_build() {
-            # Setting SHOULD_BUILD=1 allows enforcing a build
-            test -z "$SHOULD_BUILD" || {
-                echo "build enforced by SHOULD_BUILD"
-                return 0
-            }
-
-            # --quiet will exit 1 if there are differences and 0 if none.
-            # should deploy if lambda was changed
-            git diff --quiet HEAD "$PREVIOUS_REF" -- "$PROJECT_PATH" || return 0
-
-            # otherwise do not deploy.
-            return 1
-    }
-
-    # Exit successfully if nothing to build
-    should_build || {
-        echo "$PROJECT_PATH hasn't changed since last commit or release $PREVIOUS_REF. Setting build skipped flag"
-        echo ::set-output name=build_skipped::true
-
-        exit 0
-    }
-
-fi
-
 
 sh -c "docker $*"


### PR DESCRIPTION
Alternative to https://github.com/vercel/actions/pull/4.

We seem to use the action with `SHOULD_BUILD=1` everywhere so we can also remove all the "git diff" code and just pass everything to `docker build`.

I pushed a tag so this can be tested with:
```
uses: zeit/actions/docker/cli@no-diff
```